### PR TITLE
Add support for prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Divvy Changelog
 
+## v1.1.0 (2017-08-15)
+
+* Feature: Enable Prometheus metric scraping by exporting `PROMETHEUS_HTTP_PORT` and `PROMETHEUS_METRICS_PATH` environment variables.
+
 ## v1.0.1 (2017-05-03)
 
 * Bugfix: If an operation contained a glob value, any operations after it were ignored when testing the operation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.1.0 (2017-08-15)
 
-* Feature: Enable Prometheus metric scraping by exporting `PROMETHEUS_HTTP_PORT` and `PROMETHEUS_METRICS_PATH` environment variables.
+* Feature: Enable Prometheus metric scraping by exporting `HTTP_SERVICE_PORT` and `PROMETHEUS_METRICS_PATH` environment variables.
 
 ## v1.0.1 (2017-05-03)
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ The server can be configured with several environment variables.
 * `STATSD_PORT`: Port of statsd server (no default);
 * `STATSD_PREFIX`: Optional prefix to use with statsd metrics (no default).
 * `STATSD_USE_TCP`: If non-empty, use tcp instead of udp (no default).
+* `PROMETHEUS_HTTP_PORT`: Port to serve prometheus metrics from (no default).
+* `PROMETHEUS_METRICS_PATH`: HTTP path to expose prometheus metrics from (no default).
 
 ## Statistics
 
@@ -279,6 +281,15 @@ If `STATSD_HOST` and `STATSD_PORT` are given, the server will report certain met
   * `<prefix>.hit`: Time to complete `hit` operations.
 * Gauges
   * `<prefix>.connections`: Concurrent connections.
+
+Alternatively if you are using Prometheus, you may specify the `PROMETHEUS_HTTP_PORT` and `PROMETHEUS_METRICS_PATH` environment variables to collect and metrics and allow your Prometheus scraper to query them. The following metrics will be collected:
+
+* `divvy_tcp_connections_total`: Gauge of current open TCP connections.
+* `divvy_hit_duration_seconds`: Histogram of processing duration for HITs.
+* `divvy_hits_total`: Counter of all HIT operations.
+  * Labels: `status` (either `accepted` or `rejected`), `type` (either `none`, `rule`, or `default`).
+* `divvy_errors_total`: Counter of divvy errors.
+  * Labels: `code` (the type of error, such as `unknown-command`).
 
 ## Client Libraries
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ The server can be configured with several environment variables.
 * `STATSD_PORT`: Port of statsd server (no default);
 * `STATSD_PREFIX`: Optional prefix to use with statsd metrics (no default).
 * `STATSD_USE_TCP`: If non-empty, use tcp instead of udp (no default).
-* `PROMETHEUS_HTTP_PORT`: Port to serve prometheus metrics from (no default).
+* `HTTP_SERVICE_PORT`: Port to serve HTTP endpoints from, currently only exporting prometheus metrics (no default).
 * `PROMETHEUS_METRICS_PATH`: HTTP path to expose prometheus metrics from (no default).
 
 ## Statistics
@@ -282,7 +282,7 @@ If `STATSD_HOST` and `STATSD_PORT` are given, the server will report certain met
 * Gauges
   * `<prefix>.connections`: Concurrent connections.
 
-Alternatively if you are using Prometheus, you may specify the `PROMETHEUS_HTTP_PORT` and `PROMETHEUS_METRICS_PATH` environment variables to collect and metrics and allow your Prometheus scraper to query them. The following metrics will be collected:
+Alternatively if you are using Prometheus, you may specify the `HTTP_SERVICE_PORT` and `PROMETHEUS_METRICS_PATH` environment variables to collect and metrics and allow your Prometheus scraper to query them. The following metrics will be collected:
 
 * `divvy_tcp_connections_total`: Gauge of current open TCP connections.
 * `divvy_hit_duration_seconds`: Histogram of processing duration for HITs.

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const redisHost = process.env.REDIS_HOST || 'localhost';
 const redisClient = redis.createClient(redisPort, redisHost);
 const backend = new Backend({ redisClient });
 
-const prometheusHttpPort = process.env.PROMETHEUS_HTTP_PORT;
+const httpServicePort = process.env.HTTP_SERVICE_PORT;
 const prometheusMetricsPath = process.env.PROMETHEUS_METRICS_PATH;
 
 const server = new Server({
@@ -40,22 +40,22 @@ const server = new Server({
 backend.initialize().then(() => {
   console.log(`Listening on port TCP port ${server.port}, Redis host ${redisHost}:${redisPort}`);
 
-  if (prometheusHttpPort && prometheusMetricsPath) {
+  if (httpServicePort && prometheusMetricsPath) {
     WebServer.createAndServe({
-      port: parseInt(prometheusHttpPort, 10),
+      port: parseInt(httpServicePort, 10),
       metricsPath: prometheusMetricsPath,
     });
 
     const metricsLocation = url.format({
       protocol: 'http',
       hostname: '127.0.0.1',
-      port: prometheusHttpPort,
+      port: httpServicePort,
       pathname: prometheusMetricsPath.startsWith('/') ? prometheusMetricsPath : `/${prometheusMetricsPath}`,
     });
 
     console.log(`Serving prometheus metrics at ${metricsLocation}`);
-  } else if (prometheusHttpPort || prometheusMetricsPath) {
-    console.warn(`Only found one of PROMETHEUS_HTTP_PORT / PROMETHEUS_METRICS_PATH. Check your environment.`);
+  } else if (httpServicePort || prometheusMetricsPath) {
+    console.warn(`Only found one of HTTP_SERVICE_PORT / PROMETHEUS_METRICS_PATH. Check your environment.`);
   }
 
   server.serve();

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 const redis = require('redis');
+const url = require('url');
+
 const Backend = require('./src/backend');
 const Config = require('./src/config');
+const Instrumenter = require('./src/instrumenter');
 const Server = require('./src/server');
+const WebServer = require('./src/webserver');
 
 /* eslint-disable no-console */
 
@@ -18,17 +22,41 @@ const redisHost = process.env.REDIS_HOST || 'localhost';
 const redisClient = redis.createClient(redisPort, redisHost);
 const backend = new Backend({ redisClient });
 
+const prometheusHttpPort = process.env.PROMETHEUS_HTTP_PORT;
+const prometheusMetricsPath = process.env.PROMETHEUS_METRICS_PATH;
+
 const server = new Server({
+  instrumenter: new Instrumenter({
+    statsdHost: process.env.STATSD_HOST,
+    statsdPort: parseInt(process.env.STATSD_PORT, 10),
+    statsdPrefix: process.env.STATSD_PREFIX || '',
+    statsdUseTcp: !!process.env.STATSD_USE_TCP,
+  }),
   backend,
   config,
   port: process.env.PORT,
-  statsdHost: process.env.STATSD_HOST,
-  statsdPort: parseInt(process.env.STATSD_PORT, 10),
-  statsdPrefix: process.env.STATSD_PREFIX || '',
-  statsdUseTcp: !!process.env.STATSD_USE_TCP,
 });
 
 backend.initialize().then(() => {
   console.log(`Listening on port TCP port ${server.port}, Redis host ${redisHost}:${redisPort}`);
+
+  if (prometheusHttpPort && prometheusMetricsPath) {
+    WebServer.createAndServe({
+      port: parseInt(prometheusHttpPort, 10),
+      metricsPath: prometheusMetricsPath,
+    });
+
+    const metricsLocation = url.format({
+      protocol: 'http',
+      hostname: '127.0.0.1',
+      port: prometheusHttpPort,
+      pathname: prometheusMetricsPath.startsWith('/') ? prometheusMetricsPath : `/${prometheusMetricsPath}`,
+    });
+
+    console.log(`Serving prometheus metrics at ${metricsLocation}`);
+  } else if (prometheusHttpPort || prometheusMetricsPath) {
+    console.warn(`Only found one of PROMETHEUS_HTTP_PORT / PROMETHEUS_METRICS_PATH. Check your environment.`);
+  }
+
   server.serve();
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@button/divvy",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Redis-backed rate limit service.",
   "main": "index.js",
   "directories": {
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "benchmark": "node ./bin/benchmark.js",
-    "start": "node index.js config/default.ini",
+    "start": "node index.js examples/example-config.ini",
     "test": "mocha --recursive tests/"
   },
   "author": "mike wakerly <mikey@usebutton.com>",
@@ -33,6 +33,7 @@
     "carrier": "^0.3.0",
     "debug": "^2.2.0",
     "ini": "^1.3.4",
+    "prom-client": "^10.0.3",
     "redis": "^2.5.3",
     "statsd-client": "^0.2.2"
   }

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -1,0 +1,112 @@
+const PrometheusClient = require('prom-client');
+const StatsdClient = require('statsd-client');
+
+class Instrumenter {
+  /**
+   * Encapsulates support for various monitoring backends that are supported by Divvy.
+   * The list of supported backends currently includes statsd and prometheus.
+   *
+   * @param {Object}   options
+   * @param {string=}  options.statsdHost    Statsd hostname for metrics (optional, no default).
+   * @param {number=}  options.statsdPort    Statsd port (optional, no default).
+   * @param {string=}  options.statsdPrefix  Prefix to use with statsd metrics (default '');
+   * @param {boolean=} options.statsdUseTcp  If truthy, use a TCP statsd client instead of UDP.
+   */
+  constructor(options) {
+    this.options = options;
+    this.initStatsd();
+    this.initPrometheus();
+  }
+
+  /**
+   * Instantiate a new StatsdClient. If no statsd configuration is specified, this
+   * creates an object with the same interface but all of the methods are no-ops.
+   */
+  initStatsd() {
+    if (this.options.statsdHost && this.options.statsdPort) {
+      this.statsd = new StatsdClient({
+        host: this.options.statsdHost,
+        port: this.options.statsdPort,
+        prefix: this.options.statsdPrefix || '',
+        tcp: !!this.options.statsdUseTcp,
+      });
+    } else {
+      this.statsd = {
+        increment() {},
+        gauge() {},
+        timing() {},
+      };
+    }
+  }
+
+  /**
+   * Register all of the Prometheus metrics to be used by divvy. These are exposed
+   * as instance properties so we can easily clear and re-create them when testing.
+   */
+  initPrometheus() {
+    this.tcpConnectionsCounter = new PrometheusClient.Gauge({
+      name: 'divvy_tcp_connections_total',
+      help: 'Total number of open TCP connections to Divvy.',
+    });
+
+    this.hitDurationHistogram = new PrometheusClient.Histogram({
+      name: 'divvy_hit_duration_seconds',
+      help: 'Histogram of Divvy processing time for HITs.',
+    });
+
+    this.hitCounter = new PrometheusClient.Counter({
+      name: 'divvy_hits_total',
+      help: 'Counter of total HITs to Divvy.',
+      labelNames: ['status', 'type'],
+    });
+
+    this.errorCounter = new PrometheusClient.Counter({
+      name: 'divvy_errors_total',
+      help: 'Counter of total Divvy errors.',
+      labelNames: ['code'],
+    });
+  }
+
+  /**
+   * Record the current number of open TCP connections.
+   * @param {number} connections
+   */
+  gaugeCurrentConnections(connections) {
+    if (typeof connections === 'number') {
+      this.statsd.gauge('connections', connections);
+      this.tcpConnectionsCounter.set(connections);
+    }
+  }
+
+  /**
+   * Record the duration of a HIT operation
+   * @param {Date} start When the HIT request was received.
+   */
+  timeHit(start) {
+    const seconds = (Date.now() - start.valueOf()) / 1000;
+    this.statsd.timing('hit', start);
+    this.hitDurationHistogram.observe(seconds);
+  }
+
+  /**
+   * Record a HIT operation.
+   * @param {string} status The status of the hit, either "accepted" or "rejected".
+   * @param {string} type   The match type, either "rule", "default", or "none".
+   */
+  countHit(status, type) {
+    this.statsd.increment(`hit.${status}`);
+    this.statsd.increment(`hit.${status}.${type}`);
+    this.hitCounter.labels(status, type).inc();
+  }
+
+  /**
+   * Record an error.
+   * @param {string} code The divvy error code.
+   */
+  countError(code) {
+    this.statsd.increment(`error.${code}`);
+    this.errorCounter.labels(code).inc();
+  }
+}
+
+module.exports = Instrumenter;

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -1,0 +1,48 @@
+const http = require('http');
+const PrometheusClient = require('prom-client');
+
+const invariant = require('./utils').invariant;
+
+class WebServer {
+  /**
+   * @param {Object} options
+   * @param {number} options.port The port to listen on.
+   * @param {string} options.metricsPath The path to expose prometheus metrics at.
+   * @return {WebServer}
+   */
+  constructor(options) {
+    invariant(options.port !== undefined, 'Must provide options.port');
+    invariant(options.metricsPath, 'Must provide options.metricsPath');
+    this.options = options;
+    this.server = http.createServer(this.handleRequest.bind(this));
+  }
+
+  /**
+   * Create a new WebServer and start listening on the specified port.
+   * @param {Object} options
+   * @param {number} options.port The port to listen on.
+   * @param {string} options.metricsPath The path to expose prometheus metrics at.
+   * @return {WebServer}
+   */
+  static createAndServe(options) {
+    const server = new WebServer(options);
+    server.serve();
+    return server;
+  }
+
+  serve() {
+    this.server.listen(this.options.port);
+  }
+
+  handleRequest(request, response) {
+    if (request.url !== this.options.metricsPath) {
+      response.writeHead(404);
+      response.end();
+      return;
+    }
+
+    response.end(PrometheusClient.register.metrics());
+  }
+}
+
+module.exports = WebServer;

--- a/tests/instrumenter-test.js
+++ b/tests/instrumenter-test.js
@@ -1,0 +1,84 @@
+const assert = require('assert');
+const PrometheusClient = require('prom-client');
+const sinon = require('sinon');
+
+const Instrumenter = require('../src/instrumenter');
+
+describe('src/instrumenter', function () {
+  before(function () {
+    this.clock = sinon.useFakeTimers();
+  });
+
+  after(function () {
+    this.clock.restore();
+  });
+
+  beforeEach(function () {
+    // Reset the prometheus register so we don't get errors for
+    // re-creating our metrics.
+    PrometheusClient.register.clear();
+
+    // Not providing options will cause statsd to default to a mock
+    // implementation.
+    this.instrumenter = new Instrumenter({});
+
+    // Use spies for statsd assertions; for Prometheus we can just read
+    // from the registry.
+    this.instrumenter.statsd.increment = sinon.spy();
+    this.instrumenter.statsd.gauge = sinon.spy();
+    this.instrumenter.statsd.timing = sinon.spy();
+  });
+
+  it('gauges the number of current connections', function () {
+    sinon.assert.notCalled(this.instrumenter.statsd.gauge);
+    assert.equal(this.instrumenter.tcpConnectionsCounter.hashMap[''].value, 0);
+
+    this.instrumenter.gaugeCurrentConnections(50);
+    sinon.assert.calledWith(this.instrumenter.statsd.gauge, 'connections', 50);
+    assert.equal(this.instrumenter.tcpConnectionsCounter.hashMap[''].value, 50);
+
+    this.instrumenter.gaugeCurrentConnections(20);
+    sinon.assert.calledWith(this.instrumenter.statsd.gauge, 'connections', 20);
+    assert.equal(this.instrumenter.tcpConnectionsCounter.hashMap[''].value, 20);
+  });
+
+  it('records the duration of a HIT', function () {
+     // Grab a start date and move forward a second so we have some imaginary duration
+    const start = new Date();
+    this.clock.tick(1000);
+
+    sinon.assert.notCalled(this.instrumenter.statsd.timing);
+    assert.equal(this.instrumenter.hitDurationHistogram.hashMap[''].sum, 0);
+    assert.equal(this.instrumenter.hitDurationHistogram.hashMap[''].count, 0);
+
+    this.instrumenter.timeHit(start);
+    sinon.assert.callCount(this.instrumenter.statsd.timing, 1);
+    sinon.assert.calledWith(this.instrumenter.statsd.timing, 'hit', start);
+    assert.equal(this.instrumenter.hitDurationHistogram.hashMap[''].sum, 1);
+    assert.equal(this.instrumenter.hitDurationHistogram.hashMap[''].count, 1);
+  });
+
+  it('records the number of HIT operations', function () {
+    sinon.assert.notCalled(this.instrumenter.statsd.increment);
+    assert.deepEqual(this.instrumenter.hitCounter.hashMap, {});
+
+    this.instrumenter.countHit('accepted', 'rule');
+    this.instrumenter.countHit('accepted', 'rule');
+    this.instrumenter.countHit('accepted', 'none');
+    this.instrumenter.countHit('accepted', 'default');
+    this.instrumenter.countHit('rejected', 'none');
+
+    sinon.assert.callCount(this.instrumenter.statsd.increment, 10);
+    sinon.assert.calledWith(this.instrumenter.statsd.increment, 'hit.accepted');
+    sinon.assert.calledWith(this.instrumenter.statsd.increment, 'hit.rejected');
+    sinon.assert.calledWith(this.instrumenter.statsd.increment, 'hit.accepted.rule');
+    sinon.assert.calledWith(this.instrumenter.statsd.increment, 'hit.accepted.none');
+    sinon.assert.calledWith(this.instrumenter.statsd.increment, 'hit.accepted.default');
+    sinon.assert.calledWith(this.instrumenter.statsd.increment, 'hit.rejected.none');
+
+    assert.equal(this.instrumenter.hitCounter.hashMap['status:accepted,type:rule'].value, 2);
+    assert.equal(this.instrumenter.hitCounter.hashMap['status:accepted,type:none'].value, 1);
+    assert.equal(this.instrumenter.hitCounter.hashMap['status:accepted,type:default'].value, 1);
+    assert.equal(this.instrumenter.hitCounter.hashMap['status:rejected,type:none'].value, 1);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,6 +88,10 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+
 bluebird@^3.3.4:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
@@ -822,6 +826,12 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+prom-client@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-10.0.3.tgz#4c17cec9a04e1749fc8846e7f01493df3f993a2d"
+  dependencies:
+    tdigest "^0.1.1"
+
 ramda@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
@@ -1002,6 +1012,12 @@ table@^3.7.8:
     lodash "^4.0.0"
     slice-ansi "0.0.4"
     string-width "^2.0.0"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  dependencies:
+    bintrees "1.0.1"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This change introduces support for exposing an HTTP endpoint for Prometheus to scrape on a simple webserver, and abstracts away the actual logging of metrics behind a discrete Instrumenter interface.