### PR TITLE
Match non-terminal glob values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Divvy Changelog
 
+## v1.6.0 (2020-03-27)
+
+* Feature: Extend glob support to include non-terminal wildcards.
+
 ## v1.5.0 (2019-12-10)
 
 ### Breaking changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@button/divvy",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Redis-backed rate limit service.",
   "main": "index.js",
   "directories": {

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ const REGEX_ESCAPE_CHARACTERS = /[-[\]{}()+?.,\\^$|#]/g;
 const RULE_LABEL_REGEX = /^[a-zA-Z0-9_-]{1,255}$/;
 
 function isGlobValue(v) {
-  return v.endsWith('*');
+  return v.endsWith('*') || v.match(/\/\*\//);
 }
 
 class Config {

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ const REGEX_ESCAPE_CHARACTERS = /[-[\]{}()+?.,\\^$|#]/g;
 const RULE_LABEL_REGEX = /^[a-zA-Z0-9_-]{1,255}$/;
 
 function isGlobValue(v) {
-  return v.endsWith('*') || v.match(/\/\*\//);
+  return v.match(/\*/);
 }
 
 class Config {

--- a/tests/config-test.js
+++ b/tests/config-test.js
@@ -99,6 +99,31 @@ describe('src/config', function () {
         }, /Unreachable rule/);
       });
 
+      it('with an unreachable glob rule', function () {
+        const config = new Config();
+        const first = '/resource/*/first';
+        const last = '/resource/*/last';
+        config.addRule({ operation: { path: first, method: 'POST' }, creditLimit: 100, resetSeconds: 60 });
+        config.addRule({ operation: { path: first, method: 'POST' }, creditLimit: 10, resetSeconds: 20 });
+
+        assert.equal(config.rules[0].operation.path, first);
+        assert.equal(config.rules[1].operation.path, last);
+
+        config.addRule({
+          operation: { path: '/resource/*', method: 'POST' },
+          creditLimit: 100,
+          resetSeconds: 60,
+        });
+
+        assert.throws(() => {
+          config.addRule({
+            operation: { path: '/resource/*/unreachable', method: 'POST' },
+            creditLimit: 100,
+            resetSeconds: 60,
+          });
+        }, /Unreachable rule/);
+      });
+
       it('with a rule containing an invalid creditLimit', function () {
         const config = new Config();
         config.addRule({ operation: { service: 'myservice', method: 'GET' }, creditLimit: 0, resetSeconds: 60 });


### PR DESCRIPTION
This change enables non-terminal `*`s in glob values ~~, so long as they are separated by `/`~~ . Previously (currently) `parseGlob` could handle matching strings like `first/*/third`, but the the condition for matching with `parseGlob` could never trigger since the `*` occurs before the end of the string, and `isGlobValue` only checks end of string to determine if `parseGlob` will be called .