### PR TITLE
Use better default histogram buckets; v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Divvy Changelog
 
+## v1.7.0 (2020-04-21)
+
+* Instrumentation: Revised `divvy_hit_duration_seconds` historgram buckets to more appropriate values: `[1ms, 2ms, 5ms, 10ms, 100ms, 500ms]`.
+
 ## v1.6.1 (2020-03-27)
 
 * Bugfix: Broken glob test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@button/divvy",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Redis-backed rate limit service.",
   "main": "index.js",
   "directories": {

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -52,6 +52,7 @@ class Instrumenter {
     this.hitDurationHistogram = new PrometheusClient.Histogram({
       name: 'divvy_hit_duration_seconds',
       help: 'Histogram of Divvy processing time for HITs.',
+      buckets: [0.001, 0.002, 0.005, 0.01, 0.1, 0.5],
     });
 
     this.hitCounter = new PrometheusClient.Counter({

--- a/tests/instrumenter-test.js
+++ b/tests/instrumenter-test.js
@@ -56,6 +56,26 @@ describe('src/instrumenter', function () {
     sinon.assert.calledWith(this.instrumenter.statsd.timing, 'hit', start);
     assert.equal(this.instrumenter.hitDurationHistogram.hashMap[''].sum, 1);
     assert.equal(this.instrumenter.hitDurationHistogram.hashMap[''].count, 1);
+    assert.deepEqual({
+      0.001: 0,
+      0.002: 0,
+      0.005: 0,
+      0.01: 0,
+      0.1: 0,
+      0.5: 1,
+    }, this.instrumenter.hitDurationHistogram.hashMap[''].bucketValues);
+
+    const secondHit = new Date();
+    this.clock.tick(97);
+    this.instrumenter.timeHit(secondHit);
+    assert.deepEqual({
+      0.001: 0,
+      0.002: 0,
+      0.005: 0,
+      0.01: 0,
+      0.1: 1,
+      0.5: 1,
+    }, this.instrumenter.hitDurationHistogram.hashMap[''].bucketValues);
   });
 
   it('records the number of HIT operations', function () {


### PR DESCRIPTION
Replaces bad prior defaults of `[0.1, 5, 15, 50, 100, 500]`