### PR TITLE
Bugfix: Out-of-order responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Divvy Changelog
 
+## v1.7.1 (2020-05-19)
+
+* Bugfix: ensure ordered delivery of responses per connection.
+
 ## v1.7.0 (2020-04-21)
 
 * Instrumentation: Revised `divvy_hit_duration_seconds` historgram buckets to more appropriate values: `[1ms, 2ms, 5ms, 10ms, 100ms, 500ms]`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.10
+FROM node:8
 
 RUN mkdir /app
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@button/divvy",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Redis-backed rate limit service.",
   "main": "index.js",
   "directories": {

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -37,8 +37,7 @@ const error = makeResult(STATUS_ERROR);
  *   * Taking on more of the connection management (e.g, reading)
  *   * More timing metrics (end-to-end processing time of a request)
  *   * Limits on the amount of requests we'll queue against a socket
- *   * Limits on the amount of in-flight requests being actively being
- *     processed.
+ *   * Limits on the amount of in-flight requests actively being processed.
  *   * Handler timeouts
  */
 class Dispatcher {

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,0 +1,146 @@
+/* eslint-disable no-await-in-loop */
+const debug = require('debug')('divvy');
+const { invariant } = require('./utils');
+
+const STATUS_OK = 'OK';
+const STATUS_ERROR = 'ERR';
+const STATUSES = new Set([STATUS_OK, STATUS_ERROR]);
+
+const makeResult = status => message => ({ status, message });
+
+/**
+ * ok and error are functions that accept a string as input and return a
+ * { status, message } tuple understandable to a Dispatcher. These may be used
+ * for return values from handler functions.
+ */
+const ok = makeResult(STATUS_OK);
+const error = makeResult(STATUS_ERROR);
+
+/**
+ * A Dispatcher wraps a socket and ensures requests are responded to in the
+ * exact order that they're received. Additionally, it ensures responses are
+ * formatted according to the Divvy protocol.
+ *
+ * When a new connection is created, you can instantiate a Dispatcher with the
+ * socket and a request handler. The request handler is expected to accept a
+ * single request line and return a promise that either:
+ *
+ *   * Resolves with a { status, message } tuple or
+ *   * Rejects with an Error
+ *
+ * When the connection receives a line, forward it to the dispatcher via the
+ * #handle method. This will take care to invoke the handler function, and
+ * ensure responses get written in-order and according to the divvy protocol.
+ *
+ * Future improvements could include:
+ *
+ *   * Taking on more of the connection management (e.g, reading)
+ *   * More timing metrics (end-to-end processing time of a request)
+ *   * Limits on the amount of requests we'll queue against a socket
+ *   * Limits on the amount of in-flight requests being actively being
+ *     processed.
+ */
+class Dispatcher {
+  /**
+   * @param  {net.Socket} options.conn
+   * @param  {string => Promise} options.handler
+   * @return {Dispatcher}
+   */
+  constructor({ conn, handler }) {
+    invariant(!!conn, 'Must provide conn to Dispatcher');
+    invariant(typeof handler === 'function', 'Must provide handler function to Dispatcher');
+
+    this.conn = conn;
+    this.handler = handler;
+    this.queue = [];
+    this.flushing = false;
+  }
+
+  /**
+   * Process a request line. This will invoke the handler function and ensure
+   * a response is written to the socket in the order requests are received.
+   *
+   * @param  {string} line
+   */
+  handle(line) {
+    let p;
+    try {
+      p = Promise.resolve(this.handler(line));
+    } catch (e) {
+      p = Promise.reject(e);
+    }
+
+    this.queue.push(p);
+    this.flush();
+  }
+
+  /**
+   * @private
+   */
+  async flush() {
+    if (this.flushing) {
+      return;
+    }
+
+    debug('beginning dispatch flush');
+    this.flushing = true;
+
+    while (this.queue.length) {
+      const p = this.queue.shift();
+
+      try {
+        const { status, message } = await p;
+        this.write(status, message);
+      } catch (e) {
+        this.write(STATUS_ERROR, `Server error: ${e}`);
+      }
+    }
+
+    debug('finishing dispatch flush');
+    this.flushing = false;
+  }
+
+  /**
+   * @private
+   */
+  write(status, message) {
+    // Don't write if the socket is not writable. This is the case
+    // when the connection closes between event loop ticks (i.e. while a
+    // backend response is being fulfilled).
+    if (!this.conn.writable) {
+      this.destroy();
+      return;
+    }
+
+    if (!STATUSES.has(status)) {
+      status = STATUS_ERROR;
+      message = `Internal Error: Unknown status (${status})`;
+    }
+
+    if (typeof message !== 'string') {
+      status = STATUS_ERROR;
+      message = `Internal Error: Invalid message type (${typeof message})`;
+    }
+
+    if (message.includes('\n')) {
+      status = STATUS_ERROR;
+      message = `Internal Error: Message contained newlines`;
+    }
+
+    debug('writing %s response to socket', status);
+    this.conn.write(`${status} ${message}\n`);
+
+    if (status === STATUS_ERROR) {
+      this.destroy();
+    }
+  }
+
+  /**
+   * @private
+   */
+  destroy() {
+    this.conn.destroy();
+  }
+}
+
+module.exports = { Dispatcher, ok, error };

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -61,6 +61,9 @@ class Dispatcher {
    * a response is written to the socket in the order requests are received.
    *
    * @param  {string} line
+   * @return {Promise} A meaningless promise. It is returned to help tests
+   *   synchronize their assertions withe behavior internal to the Dispatcher,
+   *   but should not be relied upon for anything.
    */
   handle(line) {
     let p;

--- a/src/server.js
+++ b/src/server.js
@@ -84,6 +84,8 @@ class Server extends EventEmitter {
       this.emit('listening', server.address());
     });
     server.listen(this.port);
+
+    return () => server.close();
   }
 
   handleCommand(line, conn) {

--- a/tests/dispatcher-test.js
+++ b/tests/dispatcher-test.js
@@ -1,0 +1,223 @@
+const assert = require('assert');
+const sinon = require('sinon');
+
+const { Dispatcher, ok, error } = require('../src/dispatcher');
+
+describe('src/dispatcher', function() {
+  beforeEach(function() {
+    this.conn = {
+      write: sinon.spy(),
+      destroy: sinon.spy(),
+      writable: true,
+    };
+
+    this.handler = l => new Promise(r => setTimeout(() => r(ok(l)), parseInt(l, 10)));
+
+    this.dispatcher = new Dispatcher({
+      conn: this.conn,
+      handler: this.handler,
+    });
+  });
+
+  it('requires a valid connection and handler function', function() {
+    assert.throws(
+      () => new Dispatcher(),
+      /^Error: Must provide conn to Dispatcher$/
+    );
+
+    assert.throws(
+      () => new Dispatcher({ conn: this.conn }),
+      /^Error: Must provide handler function to Dispatcher$/
+    );
+
+    assert.throws(
+      () => new Dispatcher({ conn: this.conn, handler: 'bloop' }),
+      /^Error: Must provide handler function to Dispatcher$/
+    );
+  });
+
+  it('handles a single request', async function() {
+    await this.dispatcher.handle('1');
+
+    assert.deepStrictEqual(this.conn.write.args, [['OK 1\n']]);
+    assert.deepStrictEqual(this.conn.destroy.callCount, 0);
+  });
+
+  it('handles many requests with varying processing time', async function() {
+    // Dispatch an initial request that will have a latency greater than all
+    // others. Use the returned promise to synchronize with flushing responses.
+    const sync = this.dispatcher.handle('100');
+    for (let i = 90; i >= 0; i -= 10) {
+      this.dispatcher.handle(`${i}`);
+    }
+
+    await sync;
+
+    assert.deepStrictEqual(this.conn.write.args, [
+      ['OK 100\n'],
+      ['OK 90\n'],
+      ['OK 80\n'],
+      ['OK 70\n'],
+      ['OK 60\n'],
+      ['OK 50\n'],
+      ['OK 40\n'],
+      ['OK 30\n'],
+      ['OK 20\n'],
+      ['OK 10\n'],
+      ['OK 0\n'],
+    ]);
+
+    assert.deepStrictEqual(this.conn.destroy.callCount, 0);
+  });
+
+  it('handles multiple flush cycles', async function() {
+    let sync = this.dispatcher.handle('20');
+    this.dispatcher.handle('0');
+
+    await sync;
+
+    sync = this.dispatcher.handle('1');
+    this.dispatcher.handle('21');
+
+    await sync;
+
+    assert.deepStrictEqual(this.conn.write.args, [
+      ['OK 20\n'],
+      ['OK 0\n'],
+      ['OK 1\n'],
+      ['OK 21\n'],
+    ]);
+
+    assert.deepStrictEqual(this.conn.destroy.callCount, 0);
+  });
+
+  it('handles handler functions that return an error', async function() {
+    const handler = () => error(`doh`);
+    const dispatcher = new Dispatcher({ conn: this.conn, handler });
+
+    await dispatcher.handle('yeet?');
+
+    assert.deepStrictEqual(this.conn.write.args, [['ERR doh\n']]);
+    assert.deepStrictEqual(this.conn.destroy.callCount, 1);
+  });
+
+  it('handles handler functions that dont return a promise', async function() {
+    const handler = l => ok(`${l} yeet`);
+    const dispatcher = new Dispatcher({ conn: this.conn, handler });
+
+    await dispatcher.handle('yeet?');
+
+    assert.deepStrictEqual(this.conn.write.args, [['OK yeet? yeet\n']]);
+    assert.deepStrictEqual(this.conn.destroy.callCount, 0);
+  });
+
+  it('handles handler functions that synchronously throw', async function() {
+    const handler = l => { throw new Error(`${l}`); };
+    const dispatcher = new Dispatcher({ conn: this.conn, handler });
+
+    await dispatcher.handle('yeet?');
+
+    assert.deepStrictEqual(this.conn.write.args, [['ERR Internal Error: yeet?\n']]);
+    assert.deepStrictEqual(this.conn.destroy.callCount, 1);
+  });
+
+  it('handles handler functions that reject', async function() {
+    const handler = l => Promise.reject(new Error(`all-american ${l}`));
+    const dispatcher = new Dispatcher({ conn: this.conn, handler });
+
+    await dispatcher.handle('reject');
+
+    assert.deepStrictEqual(this.conn.write.args, [['ERR Internal Error: all-american reject\n']]);
+    assert.deepStrictEqual(this.conn.destroy.callCount, 1);
+  });
+
+  it('handles mixed rejections and destroys the socket after the first', async function() {
+    const handler = l => new Promise((res, rej) => setTimeout(
+      () => (parseInt(l, 10) % 2 === 0 ? res(ok(l)) : rej(new Error(l))),
+      parseInt(l, 10)
+    ));
+
+    const dispatcher = new Dispatcher({ conn: this.conn, handler });
+
+    const sync = dispatcher.handle('10');
+    dispatcher.handle('7');
+
+    await sync;
+
+    assert.deepStrictEqual(this.conn.write.args, [
+      ['OK 10\n'],
+      ['ERR Internal Error: 7\n'],
+    ]);
+
+    assert.deepStrictEqual(this.conn.destroy.callCount, 1);
+  });
+
+  it('handles handler functions that return an invalid value', async function() {
+    const handler = () => Promise.resolve('spuds mackenzie');
+    const dispatcher = new Dispatcher({ conn: this.conn, handler });
+
+    await dispatcher.handle('best pup');
+
+    assert.deepStrictEqual(this.conn.write.args, [
+      ['ERR Internal Error: Unknown status (undefined)\n'],
+    ]);
+
+    assert.deepStrictEqual(this.conn.destroy.callCount, 1);
+  });
+
+  it('handles handler functions that return an unknown status', async function() {
+    const handler = () => Promise.resolve({ status: 'SPUDS', message: 'MACKENZIE' });
+    const dispatcher = new Dispatcher({ conn: this.conn, handler });
+
+    await dispatcher.handle('best pup');
+
+    assert.deepStrictEqual(this.conn.write.args, [
+      ['ERR Internal Error: Unknown status (SPUDS)\n'],
+    ]);
+
+    assert.deepStrictEqual(this.conn.destroy.callCount, 1);
+  });
+
+  it('handles handler functions that return an invalid message type', async function() {
+    const handler = () => Promise.resolve(ok(23));
+    const dispatcher = new Dispatcher({ conn: this.conn, handler });
+
+    await dispatcher.handle('best pup');
+
+    assert.deepStrictEqual(this.conn.write.args, [
+      ['ERR Internal Error: Invalid message type (number)\n'],
+    ]);
+
+    assert.deepStrictEqual(this.conn.destroy.callCount, 1);
+  });
+
+  it('handles handler functions that return an invalid message', async function() {
+    const handler = () => Promise.resolve(ok('everyone\nwalk\nthe\ndinosaur'));
+    const dispatcher = new Dispatcher({ conn: this.conn, handler });
+
+    await dispatcher.handle('best pup');
+
+    assert.deepStrictEqual(this.conn.write.args, [
+      ['ERR Internal Error: Message contained newlines\n'],
+    ]);
+
+    assert.deepStrictEqual(this.conn.destroy.callCount, 1);
+  });
+
+  it('handles destroyed sockets', async function() {
+    await this.dispatcher.handle('10');
+
+    assert.deepStrictEqual(this.conn.write.args, [
+      ['OK 10\n'],
+    ]);
+
+    this.conn.writable = false;
+    await this.dispatcher.handle('10');
+
+    assert.deepStrictEqual(this.conn.write.args, [
+      ['OK 10\n'],
+    ]);
+
+    assert.deepStrictEqual(this.conn.destroy.callCount, 1);
+  });
+});

--- a/tests/instrumenter-test.js
+++ b/tests/instrumenter-test.js
@@ -43,9 +43,9 @@ describe('src/instrumenter', function () {
   });
 
   it('records the duration of a HIT', function () {
-    // Grab a start date and move forward a second so we have some imaginary duration
+    // Grab a start date and move forward a 1/2 second so we have some imaginary duration
     const start = new Date();
-    this.clock.tick(1000);
+    this.clock.tick(499);
 
     sinon.assert.notCalled(this.instrumenter.statsd.timing);
     assert.equal(this.instrumenter.hitDurationHistogram.hashMap[''].sum, 0);
@@ -54,7 +54,7 @@ describe('src/instrumenter', function () {
     this.instrumenter.timeHit(start);
     sinon.assert.callCount(this.instrumenter.statsd.timing, 1);
     sinon.assert.calledWith(this.instrumenter.statsd.timing, 'hit', start);
-    assert.equal(this.instrumenter.hitDurationHistogram.hashMap[''].sum, 1);
+    assert.equal(this.instrumenter.hitDurationHistogram.hashMap[''].sum, 0.499);
     assert.equal(this.instrumenter.hitDurationHistogram.hashMap[''].count, 1);
     assert.deepEqual({
       0.001: 0,

--- a/tests/server-test.js
+++ b/tests/server-test.js
@@ -255,6 +255,173 @@ describe('src/server', function () {
       });
     });
 
+    it('for concurrent commands', async function () {
+      this.clock.restore();
+
+      // Inject latency into the first backend hit
+      backend.hit.onCall(0).callsFake(() => new Promise(r => setTimeout(
+        () => r({ isAllowed: false, currentCredit: 0, nextResetSeconds: 60 }),
+        10
+      )));
+
+      backend.hit.onCall(1).returns(Promise.resolve({
+        isAllowed: true,
+        currentCredit: 100,
+        nextResetSeconds: 60,
+      }));
+
+      const hit1 = client.hit({
+        method: 'GET',
+        path: '/ping',
+        isAuthenticated: 'true',
+        ip: '1.2.3.4',
+      });
+
+      const hit2 = client.hit({
+        method: 'GET',
+        path: '/ping',
+        isAuthenticated: 'true',
+        ip: '1.2.3.4',
+      });
+
+      const [res1, res2] = await Promise.all([hit1, hit2]);
+
+      assert.deepEqual(res1, {
+        isAllowed: false,
+        currentCredit: 0,
+        nextResetSeconds: 60,
+      });
+
+      assert.deepEqual(res2, {
+        isAllowed: true,
+        currentCredit: 100,
+        nextResetSeconds: 60,
+      });
+    });
+
+    it('for sequential commands on the same socket', async function () {
+      backend.hit.onCall(0).returns(Promise.resolve({
+        isAllowed: false,
+        currentCredit: 0,
+        nextResetSeconds: 60,
+      }));
+
+      backend.hit.onCall(1).returns(Promise.resolve({
+        isAllowed: true,
+        currentCredit: 100,
+        nextResetSeconds: 60,
+      }));
+
+      const hit1 = await client.hit({
+        method: 'GET',
+        path: '/ping',
+        isAuthenticated: 'true',
+        ip: '1.2.3.4',
+      });
+
+      assert.deepEqual(hit1, {
+        isAllowed: false,
+        currentCredit: 0,
+        nextResetSeconds: 60,
+      });
+
+      const hit2 = await client.hit({
+        method: 'GET',
+        path: '/ping',
+        isAuthenticated: 'true',
+        ip: '1.2.3.4',
+      });
+
+      assert.deepEqual(hit2, {
+        isAllowed: true,
+        currentCredit: 100,
+        nextResetSeconds: 60,
+      });
+    });
+
+    it('for concurrent requests on different sockets', async function() {
+      // We will create two connections. On the default connection, we will
+      // write to HITs, the first of which will be very slow to process, and
+      // the second of which will be fast.
+      //
+      // Concurrently, we will send a single HIT on another connection, which
+      // we expect to not wait on the other socket.
+      //
+      // This array will keep track of who finishes when.
+      //
+      const sequence = [];
+      const client2 = getClient();
+
+      await new Promise(r => client2.on('connected', r));
+
+      this.clock.restore();
+
+      // Inject latency into the first backend hit
+      backend.hit.onCall(0).callsFake(() => new Promise(r => setTimeout(
+        () => r({ isAllowed: false, currentCredit: 0, nextResetSeconds: 60 }),
+        10
+      )));
+
+      backend.hit.onCall(1).returns(Promise.resolve({
+        isAllowed: true,
+        currentCredit: 100,
+        nextResetSeconds: 60,
+      }));
+
+      backend.hit.onCall(2).returns(Promise.resolve({
+        isAllowed: true,
+        currentCredit: 200,
+        nextResetSeconds: 60,
+      }));
+
+      const hit1 = client.hit({
+        method: 'GET',
+        path: '/ping',
+        isAuthenticated: 'true',
+        ip: '1.2.3.4',
+      }).then((r) => { sequence.push('socket 1; hit 1'); return r; });
+
+      const hit2 = client.hit({
+        method: 'GET',
+        path: '/ping',
+        isAuthenticated: 'true',
+        ip: '1.2.3.4',
+      }).then((r) => { sequence.push('socket 1; hit 2'); return r; });
+
+      const hit3 = client2.hit({
+        method: 'GET',
+        path: '/ping',
+        isAuthenticated: 'true',
+        ip: '1.2.3.4',
+      }).then((r) => { sequence.push('socket 2; hit 1'); return r; });
+
+      const [res1, res2, res3] = await Promise.all([hit1, hit2, hit3]);
+
+      assert.deepEqual(res1, {
+        isAllowed: false,
+        currentCredit: 0,
+        nextResetSeconds: 60,
+      });
+
+      assert.deepEqual(res2, {
+        isAllowed: true,
+        currentCredit: 100,
+        nextResetSeconds: 60,
+      });
+
+      assert.deepEqual(res3, {
+        isAllowed: true,
+        currentCredit: 200,
+        nextResetSeconds: 60,
+      });
+
+      assert.deepEqual(sequence, [
+        'socket 2; hit 1',
+        'socket 1; hit 1',
+        'socket 1; hit 2',
+      ]);
+    });
+
     it('for an unknown command', function (done) {
       client._enqueueMessage('EGGPLANT not-tasty\n').promise.then(() => {
         done(new Error('Should have failed'));


### PR DESCRIPTION
### Problem Statement

For a given connection, Divvy clients expect responses to be written back to a socket in the exact order they were written to the socket. That is, if a client writes the following:

```
HIT a=1\n
HIT a=2\n
HIT a=3\n
```

it expects the rate limit response for 1 to be written back first, followed by 2, and then 3, regardless of how long it may have taken to evaluate a particular `HIT`. 

If processing `HIT a=1` takes 100ms and the subsequent `HIT`s take 1ms, we expect 2 and 3 to queue up behind 1 for the full 100ms, after which all three can be written _in order_.

I believe the current implementation of Divvy doesn't enforce this expectation, which can lead to out-or-order delivery of messages. The effect of this is clients would confuse one response for another and possibly apply the wrong rate limit policy to a request.

To demonstrate this, 9cee4bb1da1f768207b101d1d2b3967ef22362fd adds a few tests that I believe should pass, but fail under the current implementation. The goal of this PR is broadly: make those pass.

### The Fix

I tried to apply a fix as leanly as possible, `TODO`ing a number of items I thought would be neat to tackle along the way, but would diffuse the intent of this change.

In summary: I added the concept of a `Dispatcher`, which is a stateful object that wraps a socket and is responsible for:

1) Ensuring that requests received against a socket are responded to in precisely the order they arrived
2) The top-level divvy response protocol

Responsibility (2) was tacked on simply so the Dispatcher could properly recover from a poorly written "handler" function: it can catch rejections and respond to the client with an error before destroying the socket.

A handler function is how a request is actually processed. It's fed a request line from the dispatcher and is expected to resolve a particular response shape. Handler functions may take as much time fulfilling a request as they need: the dispatcher will ensure that no other requests for the socket jump the line and write to the socket before it's said its piece.

### In Addition...

This PR cleans up a few testing difficulties I ran into when starting up this change:

* 888f126a4799902e0ab471c2cba94a0f5797ddc6 fixes a test that was failing, and appeared to be failing _correctly_
* c40dba7d03e82b02b95e6fe6646592c9aec1a1af fixes the test suite hanging the node process after it has completed. This was done by adding some socket teardown logic. 

This PR is probably easiest reviewed commit-by-commit: I tried to make it as coherent as possible. Very happy to take on extra changes (like end-to-end timing metrics) if the reviewer thinks appropriate!

### Poor Man's CI

Tested against node `v8.11.2` and `v12.13.0`. 

```
$ yarn test
yarn run v1.19.2
$ mocha --recursive tests/


  src/config
    ini: #addRule and #findRule
      ✓ for normal rules
      ✓ with an unreachable rule
      ✓ with an unreachable glob rule
      ✓ with a rule containing an invalid creditLimit
      ✓ with a rule containing an invalid label
      ✓ with a rule containing a duplicate label
      ✓ with a rule where resetSeconds < 1
      ✓ handles simple glob keys
      ✓ with a glob key proceeded by normal key
      ✓ with a canary rule
    json: #addRule and #findRule
      ✓ for normal rules
      ✓ with an unreachable rule
      ✓ with an unreachable glob rule
      ✓ with a rule containing an invalid creditLimit
      ✓ with a rule containing an invalid label
      ✓ with a rule containing a duplicate label
      ✓ with a rule where resetSeconds < 1
      ✓ handles simple glob keys
      ✓ with a glob key proceeded by normal key
      ✓ with a canary rule
    #parseGlob
      ✓ returns a simple regex
      ✓ escapes hyphens
      ✓ escapes brackets
      ✓ escapes braces
      ✓ escapes parens
      ✓ escapes plus signs
      ✓ escapes question marks
      ✓ escapes periods
      ✓ escapes commas
      ✓ escapes carats
      ✓ escapes dollar signs
      ✓ escapes pipes
      ✓ escapes octothorpes

  src/dispatcher
    ✓ requires a valid connection and handler function
    ✓ handles a single request
    ✓ handles many requests with varying processing time (101ms)
    ✓ handles multiple flush cycles (47ms)
    ✓ handles handler functions that return an error
    ✓ handles handler functions that dont return a promise
    ✓ handles handler functions that synchronously throw
    ✓ handles handler functions that reject
    ✓ handles mixed rejections and destroys the socket after the first
    ✓ handles handler functions that return an invalid value
    ✓ handles handler functions that return an unknown status
    ✓ handles handler functions that return an invalid message type
    ✓ handles handler functions that return an invalid message
    ✓ handles destroyed sockets

  src/instrumenter
    ✓ gauges the number of current connections
    ✓ records the duration of a HIT
    ✓ records the number of HIT operations

  eslint
    ✓ should have no errors in index.js (1385ms)
    ✓ should have no errors in scripts/convert-config.js (42ms)
    ✓ should have no errors in src/backend.js (79ms)
    ✓ should have no errors in src/config.js (145ms)
    ✓ should have no errors in src/constants.js
    ✓ should have no errors in src/dispatcher.js (58ms)
    ✓ should have no errors in src/errors.js
    ✓ should have no errors in src/instrumenter.js (60ms)
    ✓ should have no errors in src/server.js (88ms)
    ✓ should have no errors in src/utils.js (78ms)
    ✓ should have no errors in src/webserver.js
    ✓ should have no errors in tests/config-test.js (159ms)
    ✓ should have no errors in tests/dispatcher-test.js (125ms)
    ✓ should have no errors in tests/instrumenter-test.js (81ms)
    ✓ should have no errors in tests/lint-test.js
    ✓ should have no errors in tests/server-test.js (223ms)
    ✓ should have no errors in tests/utils-test.js (82ms)

  src/server
    #serve
      ✓ for an operation where all params match
      ✓ for an operation where some params match
      ✓ for an operation with no actor
      ✓ for an operation that matches a passing canary rule
      ✓ for an operation that matches a rejecting canary rule rule
      ✓ for concurrent commands
      ✓ for sequential commands on the same socket
      ✓ for concurrent requests on different sockets
      ✓ for an unknown command
      ✓ for a malformed command
      ✓ tracks connection close
      ✓ tracks connections
    Server.getMatchType
      ✓ returns none for null rules (no match)
      ✓ returns rule for rule matches
      ✓ returns default for empty rule matches

  src/utils
    #readString
      ✓ for valid strings
      ✓ for invalid strings
    #consumeChar
      ✓ finds expected char
      ✓ errors when missing
    #parseOperationString
      ✓ for well-formed strings
      ✓ for malformed strings
    #parseCommand
      HIT
        ✓ with an empty operation
        ✓ with a simple operation
      UNKNOWN
        ✓ throws an error
    #stringifyObjectValues
      ✓ throws errors on non-object inputs
      ✓ returns a copy of input with stringified values


  93 passing (3s)

✨  Done in 9.64s.
```